### PR TITLE
Small autoassigner improvements

### DIFF
--- a/src/reviewerQueue.js
+++ b/src/reviewerQueue.js
@@ -113,7 +113,9 @@ HUBOT_GITHUB_REVIEWER_EMAIL_MAP: ${ghReviewerEmailMap}\
     let reviewerEmailMap = JSON.parse(ghReviewerEmailMap);
     for (let event of travelEvents) {
       let reviewerLogin = reviewerEmailMap[event.creator.email];
-      reviewersOnVacation[reviewerLogin] = true;
+      if (event.summary.match(/(ooo|vacation)/i)) {
+        reviewersOnVacation[reviewerLogin] = true;
+      }
     }
 
     // pick reviewer

--- a/src/reviewerQueue.js
+++ b/src/reviewerQueue.js
@@ -125,6 +125,11 @@ HUBOT_GITHUB_REVIEWER_EMAIL_MAP: ${ghReviewerEmailMap}\
       reviewers = reviewers.filter((r) => r.login !== assignee.login);
     }
 
+    if (reviewers.length === 0) {
+      msg.reply('No available reviewers, sorry!');
+      return;
+    }
+
     // pick first reviewer from the queue
     const newReviewer = reviewers[0];
     robot.logger.info(`Choose from queue: ${newReviewer.login}`);


### PR DESCRIPTION
- Don't crash if the candidate reviewer list is empty.
- Only check calendar events that include "OOO" or "vacation". (This way being WFH doesn't get you out of code reviews.)